### PR TITLE
Fix reset password route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   end
 
   resources :user_sessions, only: [:new, :create, :destroy]
-  resources :password_reset, only: [:create, :edit, :update]
+  resources :password_resets, only: [:create, :edit, :update]
 
   get 'login' => 'user_sessions#new', as: :login
   delete 'logout' => 'user_sessions#destroy', as: :logout


### PR DESCRIPTION
There's a typo in `password_reset` route, causing error on login page.