### PR TITLE
add-version-to-migration

### DIFF
--- a/db/migrate/20101210151424_create_users.rb
+++ b/db/migrate/20101210151424_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[5.2]
   def self.up
     create_table :users do |t|
       t.string :email, null: false

--- a/db/migrate/20101224223622_add_activation_to_users.rb
+++ b/db/migrate/20101224223622_add_activation_to_users.rb
@@ -1,4 +1,4 @@
-class AddActivationToUsers < ActiveRecord::Migration
+class AddActivationToUsers < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :activation_state, :string, default: nil
     add_column :users, :activation_code, :string, default: nil

--- a/db/migrate/20101224223623_add_remember_me_token_to_users.rb
+++ b/db/migrate/20101224223623_add_remember_me_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddRememberMeTokenToUsers < ActiveRecord::Migration
+class AddRememberMeTokenToUsers < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :remember_me_token, :string, default: nil
     add_column :users, :remember_me_token_expires_at, :datetime, default: nil

--- a/db/migrate/20101224223624_add_reset_password_to_users.rb
+++ b/db/migrate/20101224223624_add_reset_password_to_users.rb
@@ -1,4 +1,4 @@
-class AddResetPasswordToUsers < ActiveRecord::Migration
+class AddResetPasswordToUsers < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :reset_password_token, :string, default: nil
     add_column :users, :reset_password_token_expires_at, :datetime, default: nil

--- a/db/migrate/20101224223625_add_activity_logging_to_users.rb
+++ b/db/migrate/20101224223625_add_activity_logging_to_users.rb
@@ -1,4 +1,4 @@
-class AddActivityLoggingToUsers < ActiveRecord::Migration
+class AddActivityLoggingToUsers < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :last_login_at,     :datetime, default: nil
     add_column :users, :last_logout_at,    :datetime, default: nil

--- a/db/migrate/20101224223626_add_brute_force_protection_to_users.rb
+++ b/db/migrate/20101224223626_add_brute_force_protection_to_users.rb
@@ -1,4 +1,4 @@
-class AddBruteForceProtectionToUsers < ActiveRecord::Migration
+class AddBruteForceProtectionToUsers < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :failed_logins_count, :integer, default: 0
     add_column :users, :lock_expires_at, :datetime, default: nil

--- a/db/migrate/20110225214205_create_user_providers.rb
+++ b/db/migrate/20110225214205_create_user_providers.rb
@@ -1,4 +1,4 @@
-class CreateUserProviders < ActiveRecord::Migration
+class CreateUserProviders < ActiveRecord::Migration[5.2]
   def self.up
     create_table :user_providers do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20110421202911_add_admin_user.rb
+++ b/db/migrate/20110421202911_add_admin_user.rb
@@ -1,4 +1,4 @@
-class AddAdminUser < ActiveRecord::Migration
+class AddAdminUser < ActiveRecord::Migration[5.2]
   def self.up
     add_column :users, :type, :string
   end

--- a/db/migrate/20161213041715_add_last_login_from_ip_address_to_users.rb
+++ b/db/migrate/20161213041715_add_last_login_from_ip_address_to_users.rb
@@ -1,4 +1,4 @@
-class AddLastLoginFromIpAddressToUsers < ActiveRecord::Migration
+class AddLastLoginFromIpAddressToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :last_login_from_ip_address, :string, default: nil
   end


### PR DESCRIPTION
It failed if it executed `bin/rails db: migrate RAILS_ENV=development`.
It is necessary to change migration file corresponding to rails 5.2.2 upgrade.
So I fixed it.